### PR TITLE
fix Makefile for openwrt_15.05

### DIFF
--- a/lora-gateway/Makefile
+++ b/lora-gateway/Makefile
@@ -44,7 +44,7 @@ define Package/lora-gateway-tests
   CATEGORY:=Network
   SUBMENU:=LoRaWAN
   TITLE:=Test programs for libloragw
-  DEPENDS:=+libloragw
+  DEPENDS:=+libloragw +librt
 endef
 
 define Package/lora-gateway-utils

--- a/packet-forwarder/Makefile
+++ b/packet-forwarder/Makefile
@@ -28,7 +28,7 @@ $(call Package/packet-forwarder/Default)
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=LoRaWAN
-  DEPENDS:=+libloragw
+  DEPENDS:=+libloragw +librt
 endef
 
 define Package/packet-forwarder/description


### PR DESCRIPTION
在op15.05测试需要添加库才能编译通过，感谢您的开源。