### PR TITLE
Add luci-compat to luci-app-pkg-fwd dependencies

### DIFF
--- a/luci-app-pkg-fwd/Makefile
+++ b/luci-app-pkg-fwd/Makefile
@@ -19,7 +19,7 @@ define Package/luci-app-pkt-fwd
 	SUBMENU:=3. Applications
 	TITLE:=Semtech LoRa Packet Forward Configuration Interface
 	PKGARCH:=all
-	DEPENDS:=+lora-packet-forwarder
+	DEPENDS:=+lora-packet-forwarder +luci-compat
 endef
 
 define Build/Compile


### PR DESCRIPTION
Pages from the luci-app-pkg-fwd package won't be rendered if package
luci-compat is not installed.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>