### PR TITLE
Add luci-compat to luci-app-basicstation dependencies

### DIFF
--- a/luci-app-basicstation/Makefile
+++ b/luci-app-basicstation/Makefile
@@ -19,7 +19,7 @@ define Package/luci-app-basicstation
 	SUBMENU:=3. Applications
 	TITLE:=Semtech Basicstation Configuration Interface
 	PKGARCH:=all
-	DEPENDS:=+basicstation
+	DEPENDS:=+basicstation +luci-compat
 endef
 
 define Build/Compile


### PR DESCRIPTION
Pages from the luci-app-basicstation package won't be rendered if package luci-compat is not installed. Same as #26.